### PR TITLE
Feat/uvx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ This MCP server enables AI assistants (like Cursor, Claude Desktop, etc.) to sea
    ```bash
    ast-grep --version
    ```
+
+## Running with `uvx`
+
+You can run the server directly from GitHub using `uvx`:
+
+```bash
+uvx --from git+https://github.com/ast-grep/ast-grep-mcp ast-grep-server
+```
+
+This is useful for quickly trying out the server without cloning the repository.
+
 ## Configuration
 
 ### For Cursor

--- a/main.py
+++ b/main.py
@@ -136,7 +136,7 @@ def run_ast_grep_yaml(yaml: str, project_folder: str) -> List[dict[str, Any]]:
         print("Command not found")
         return []
 
-def run_mcp_server():
+def run_mcp_server() -> None:
     """
     Run the MCP server.
     This function is used to start the MCP server when this script is run directly.

--- a/main.py
+++ b/main.py
@@ -136,5 +136,12 @@ def run_ast_grep_yaml(yaml: str, project_folder: str) -> List[dict[str, Any]]:
         print("Command not found")
         return []
 
+def run_mcp_server():
+    """
+    Run the MCP server.
+    This function is used to start the MCP server when this script is run directly.
+    """
+    mcp.run(transport="stdio")
+
 if __name__ == "__main__":
-    mcp.run(transport = "stdio")
+    run_mcp_server()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ dependencies = [
     "pydantic>=2.11.0",
     "mcp[cli]>=1.6.0",
 ]
+
+[project.scripts]
+ast-grep-server = "main:mcp.run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ dependencies = [
 ]
 
 [project.scripts]
-ast-grep-server = "main:mcp.run"
+ast-grep-server = "main:run_mcp_server"


### PR DESCRIPTION
This pull request introduces enhancements to streamline the usage and deployment of the MCP server and updates its configuration. The most notable changes include adding instructions for running the server with `uvx`, refactoring the script entry point, and registering a new script in the project configuration.

### Enhancements to server usage:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R58): Added instructions for running the MCP server directly from GitHub using `uvx`, enabling users to try the server without cloning the repository.

### Refactoring and configuration updates:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L139-R147): Refactored the script to include a dedicated `run_mcp_server` function for starting the MCP server, and updated the `__main__` block to call this function.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R11-R13): Registered a new script, `ast-grep-server`, pointing to the `run_mcp_server` function, simplifying server execution via the project configuration.